### PR TITLE
Update URIs of organisation ID to match route

### DIFF
--- a/src/main/resources/morph-enriched.xml
+++ b/src/main/resources/morph-enriched.xml
@@ -96,10 +96,10 @@
 		<!-- new-id: isil for Sigel, and Pseudo isil for DBS data-->
 		<choose>
 			<data source="008H.e" name="\@id">
-				<regexp match="(.*)" format="http://data.lobid.org/organisation/${1}" />
+				<regexp match="(.*)" format="http://data.lobid.org/organisations/${1}" />
 				<not-equals string="NULL" />
 			</data>			
-			<combine name="\@id" value="http://data.lobid.org/organisation/DBS-${inr}">
+			<combine name="\@id" value="http://data.lobid.org/organisations/DBS-${inr}">
 				<data source="inr" name="inr">
 					<not-equals string="NULL" />
 				</data>


### PR DESCRIPTION
Use plural form ('organisations') in URI: data.lobid.org/organisations/DE-9 instead of data.lobid.org/organisation/DE-9
