### PR TITLE
Add type information for DBS-only entries

### DIFF
--- a/src/main/resources/morph-enriched.xml
+++ b/src/main/resources/morph-enriched.xml
@@ -5,14 +5,15 @@
 	<rules>		
 		<data source="nam|029A.a" name="\@context">
 			<constant value="http://beta.lobid.org/organisations/context.jsonld" />
-		</data>		
-		<combine name="type" value="${typeurl}">
-			<data source="nam|029A.a" />
-			<data source="035E.f" name="typeurl">
+		</data>
+		<choose>
+			<data source="035E.f" name="type">
 				<lookup in="libtype_map" />
 			</data>
-		</combine>
-		
+			<data source="inr" name="type">
+				<constant value="http://schema.org/Library" />
+			</data>
+		</choose>
 		<choose>
 			<data source="gemeindekennzahl" name="rs">
 				<regexp match="(\d{11})" format="0${1}"/>

--- a/src/test/resources/test_morph-enriched.xml
+++ b/src/test/resources/test_morph-enriched.xml
@@ -21,7 +21,7 @@
 			<cgxml version="1.0" xmlns="http://www.culturegraph.org/cgxml">
 				<records>
 					<record id="de-456">
-						<!--<literal name="inr" value="dbs-id" />-->
+						<literal name="type" value="http://schema.org/Library" /> 
 						<entity name="classification">
 							<literal name="id" value="http://purl.org/lobid/libtype#n60" />
 							<literal name="value" value="Universitätsbibliothek" />


### PR DESCRIPTION
* Type information is generated from Sigel field 035E.f and lookup map for Sigel organisations
* For DBS-only data, however, type is constantly http://schema.org/Library 
* Fix for #29 