### PR TITLE
Fix update mechanism for Sigel data

### DIFF
--- a/src/main/java/flow/Enrich.java
+++ b/src/main/java/flow/Enrich.java
@@ -100,7 +100,7 @@ public class Enrich {
 			continueWith(flowUpdates, wait);
 			updateOpenerList.add(openSigelUpdates);
 			start = addDays(start, intervalSize);
-			if (i == intervals - 1)
+			if (i == intervals - 2)
 				end = Sigel.getToday();
 			else
 				end = addDays(end, intervalSize);


### PR DESCRIPTION
Adjust method buildUpdatePipe of class Enrich so that the last interval ends with the date of today. This should (at least partially) solve #34. 