### PR TITLE
Infer addressCountry from DBS iso field via iso3-country-map

### DIFF
--- a/src/main/resources/morph-dbs.xml
+++ b/src/main/resources/morph-dbs.xml
@@ -17,5 +17,17 @@
 		<data source="_else">
 			<not-equals string="NULL" />
 		</data>
+		<choose name="addressCountry">
+			<data source="iso">
+				<lookup in="iso3-country-map" />
+			</data>
+			<data source="_id">
+				<constant value="Germany"/>
+			</data>
+		</choose>
 	</rules>
+	<maps>
+		<filemap name="iso3-country-map"
+			files="http://lobid.org/download/lookup-tables/data/iso3-country-map.csv" />
+	</maps>
 </metamorph>

--- a/src/test/resources/test_morph-dbs.xml
+++ b/src/test/resources/test_morph-dbs.xml
@@ -11,6 +11,12 @@
 					<record id="2">
 						<literal name="inr" value="xyz456" />
 						<literal name="isil" value="de-789" />
+						<literal name="iso" value="DEU" />
+					</record>
+					<record id="3">
+						<literal name="inr" value="aut001" />
+						<literal name="isil" value="AT-001" />
+						<literal name="iso" value="AUT" />
 					</record>
 				</records>
 			</cgxml>
@@ -23,11 +29,19 @@
 					<record id="1">
 						<literal name="_id" value="abc123" />
 						<literal name="inr" value="abc123" />
+						<literal name="addressCountry" value="Germany" />
 					</record>
 					<record id="2">
 						<literal name="_id" value="xyz456" />
 						<literal name="inr" value="xyz456" />
 						<literal name="isil" value="de-789" />
+						<literal name="addressCountry" value="Germany" />
+					</record>
+					<record id="3">
+						<literal name="_id" value="aut001" />
+						<literal name="inr" value="aut001" />
+						<literal name="isil" value="AT-001" />
+						<literal name="addressCountry" value="Austria" />
 					</record>
 				</records>
 			</cgxml>


### PR DESCRIPTION
"addressCountry" information is also inferred from DBS data now. A new .csv lookup table has been stored on the server for this purpose, containing a mapping of iso3-codes and countries (analogous to the existing iso2-code lookup table). Added test cases for countries.

The presumable switch from fully spelled countries to iso codes in our result data is going to be done in a separate ticket.