### PR TITLE
Issue/#50

### DIFF
--- a/src/main/java/flow/Constants.java
+++ b/src/main/java/flow/Constants.java
@@ -50,4 +50,8 @@ public class Constants {
 					.put("client.transport.ping_timeout", 20, TimeUnit.SECONDS).build());
 	protected static final Client ES_CLIENT = TC.addTransportAddress(NODE_1);
 
+	// GEO DATA LOOKUP
+	protected static final String GEO_SERVER_NAME = "localhost";
+	protected static final String GEO_SERVER_PORT = "9001";
+
 }

--- a/src/main/java/flow/Enrich.java
+++ b/src/main/java/flow/Enrich.java
@@ -56,10 +56,11 @@ public class Enrich {
 		int updateIntervals =
 				calculateIntervals(startOfUpdates, Helpers.getToday(), intervalSize);
 
-		CloseSupressor<Triple> wait = new CloseSupressor<>(2);
-		TripleSort sortTriples = new TripleSort();
+		final CloseSupressor<Triple> wait = new CloseSupressor<>(2);
+		final TripleSort sortTriples = new TripleSort();
+		final TripleRematch rematchTriples = new TripleRematch("isil");
 
-		String sigelTempFilesLocation =
+		final String sigelTempFilesLocation =
 				Constants.MAIN_RESOURCES_PATH + Constants.OUTPUT_PATH;
 
 		// SETUP SIGEL DUMP
@@ -79,14 +80,15 @@ public class Enrich {
 				Helpers.createTripleStream(true);
 		Sigel.setupSigelMorph(splitFileOpener).setReceiver(streamToTriplesDump);
 		Helpers.setupTripleStreamToWriter(streamToTriplesDump, wait, sortTriples,
-				aOutputPath);
+				rematchTriples, aOutputPath);
 
 		// SETUP DBS
 		final FileOpener openDbs = new FileOpener();
 		final StreamToTriples streamToTriplesDbs = Helpers.createTripleStream(true);
 		final StreamToTriples flowDbs = //
 				Dbs.morphDbs(openDbs).setReceiver(streamToTriplesDbs);
-		Helpers.setupTripleStreamToWriter(flowDbs, wait, sortTriples, aOutputPath);
+		Helpers.setupTripleStreamToWriter(flowDbs, wait, sortTriples,
+				rematchTriples, aOutputPath);
 
 		// PROCESS SIGEL
 		Sigel.processSigelSplitting(openSigelDump,

--- a/src/main/java/flow/EnrichSample.java
+++ b/src/main/java/flow/EnrichSample.java
@@ -42,8 +42,9 @@ public class EnrichSample {
 
 	static void processSample(final String aOutputPath) throws IOException {
 
-		CloseSupressor<Triple> wait = new CloseSupressor<>(2);
-		TripleSort sortTriples = new TripleSort();
+		final CloseSupressor<Triple> wait = new CloseSupressor<>(2);
+		final TripleSort sortTriples = new TripleSort();
+		final TripleRematch rematchTriples = new TripleRematch("isil");
 
 		// Sigel Splitting
 		final FileOpener sourceFileOpener = new FileOpener();
@@ -57,7 +58,8 @@ public class EnrichSample {
 		final FileOpener openDbs = new FileOpener();
 		StreamToTriples dbsFlow = //
 				Dbs.morphDbs(openDbs).setReceiver(Helpers.createTripleStream(true));
-		Helpers.setupTripleStreamToWriter(dbsFlow, wait, sortTriples, aOutputPath);
+		Helpers.setupTripleStreamToWriter(dbsFlow, wait, sortTriples,
+				rematchTriples, aOutputPath);
 		Dbs.processDbs(openDbs, DBS_LOCATION);
 
 		// Sigel Morph
@@ -65,7 +67,7 @@ public class EnrichSample {
 		StreamToTriples sigelFlow = Sigel.setupSigelMorph(splitFileOpener)
 				.setReceiver(Helpers.createTripleStream(true));
 		Helpers.setupTripleStreamToWriter(sigelFlow, wait, sortTriples,
-				aOutputPath);
+				rematchTriples, aOutputPath);
 		Sigel.processSigelMorph(splitFileOpener, SIGEL_TEMP_FILES_LOCATION);
 	}
 

--- a/src/main/java/flow/Helpers.java
+++ b/src/main/java/flow/Helpers.java
@@ -73,12 +73,13 @@ public class Helpers {
 	 */
 	static void setupTripleStreamToWriter(final StreamToTriples flow,
 			CloseSupressor<Triple> wait, TripleSort sortTriples,
-			final String aOutputPath) {
+			final TripleRematch rematchTriples, final String aOutputPath) {
+
 		final TripleFilter tripleFilter = new TripleFilter();
 		tripleFilter.setSubjectPattern(".+"); // Remove entries without id
 		final Metamorph morph =
 				new Metamorph(Constants.MAIN_RESOURCES_PATH + "morph-enriched.xml");
-		final TripleRematch rematchTriples = new TripleRematch("isil");
+
 		sortTriples.setBy(Compare.SUBJECT);
 		final JsonEncoder encodeJson = Helpers.createJsonEncoder(true);
 		final ObjectWriter<String> writer = new ObjectWriter<>(aOutputPath);

--- a/src/main/java/flow/Helpers.java
+++ b/src/main/java/flow/Helpers.java
@@ -4,6 +4,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
 import org.culturegraph.mf.morph.Metamorph;
+import org.culturegraph.mf.morph.maps.RestMap;
 import org.culturegraph.mf.stream.converter.JsonEncoder;
 import org.culturegraph.mf.stream.converter.JsonToElasticsearchBulk;
 import org.culturegraph.mf.stream.converter.StreamToTriples;
@@ -79,6 +80,19 @@ public class Helpers {
 		tripleFilter.setSubjectPattern(".+"); // Remove entries without id
 		final Metamorph morph =
 				new Metamorph(Constants.MAIN_RESOURCES_PATH + "morph-enriched.xml");
+
+		// GEO LOOKUP
+		RestMap addDbsLatMap = new RestMap();
+		RestMap addDbsLongMap = new RestMap();
+		RestMap addDbsPostalCodeMap = new RestMap();
+		String server =
+				"http://" + Constants.GEO_SERVER_NAME + ":" + Constants.GEO_SERVER_PORT;
+		addDbsLatMap.setUrl(server + "/lat/${key}");
+		addDbsLongMap.setUrl(server + "/long/${key}");
+		addDbsPostalCodeMap.setUrl(server + "/postcode/${key}");
+		morph.putMap("addLatMap", addDbsLatMap);
+		morph.putMap("addLongMap", addDbsLongMap);
+		morph.putMap("addPostalCodeMap", addDbsPostalCodeMap);
 
 		sortTriples.setBy(Compare.SUBJECT);
 		final JsonEncoder encodeJson = Helpers.createJsonEncoder(true);

--- a/src/main/resources/morph-enriched.xml
+++ b/src/main/resources/morph-enriched.xml
@@ -156,6 +156,11 @@
 			<data source="postalCodeOther" name="plz" />
 			<data source="streetAddressOther" name="str" />
 		</combine>
+		<combine name="@geoLookupDbs" value="${plz}/${ort}/${land}" flushWith="record">
+			<data source="addressCountry" name="land" />
+			<data source="plz" name="plz" />
+			<data source="ort" name="ort" />
+		</combine>	
 		
 		<!-- Locations -->
 		<entity name="location[]" flushWith="record">
@@ -209,11 +214,17 @@
 						<data source="@geoLookupVisitor" name="lat">
 							<lookup in="geolocation-lat_map" />
 						</data>
+						<data source="@geoLookupDbs" name="lat">
+							<lookup in="addLatMap" />
+						</data>
 					</choose>
 					<choose>
 						<data source="lonVisitor" name="lon" />
 						<data source="@geoLookupVisitor" name="lon">
 							<lookup in="geolocation-lon_map" />
+						</data>
+						<data source="@geoLookupDbs" name="lon">
+							<lookup in="addLongMap" />
 						</data>
 					</choose>
 				</entity>

--- a/src/main/resources/morph-enriched.xml
+++ b/src/main/resources/morph-enriched.xml
@@ -156,24 +156,23 @@
 			<data source="postalCodeOther" name="plz" />
 			<data source="streetAddressOther" name="str" />
 		</combine>
-		<combine name="@geoLookupDbs" value="${plz}/${ort}/${land}" flushWith="record">
+		<combine name="@geoLookupDbs" value="${str}/${ort}/${land}" flushWith="record">
 			<data source="addressCountry" name="land" />
-			<data source="plz" name="plz" />
+			<data source="str" name="str" />
 			<data source="ort" name="ort" />
 		</combine>	
 		
 		<!-- Locations -->
 		<entity name="location[]" flushWith="record">
 			<entity name="place" flushWith="record">
-				<data source="localityVisitor|plz" name="type">
+				<data source="localityVisitor|str" name="type">
 					<regexp match="(.*)" format="http://schema.org/Place" />
 				</data>
 				<data source="descriptionVisitor" name="description"/>
 				<entity name="address" flushWith="record">
 					<choose>
 						<data source="streetAddressVisitor" name="streetAddress" />
-						<!-- plz stand for street address in dbs data -->
-						<data source="plz" name="streetAddress">
+						<data source="str" name="streetAddress">
 							<not-equals string="NULL"/>
 						</data>
 					</choose>
@@ -182,6 +181,7 @@
 						<data source="ort" name="addressLocality" />
 					</choose>
 					<data source="postalCodeVisitor" name="postalCode" />
+					<data source="plz" name="postalCode" />
 					<choose>
 						<data source="countryVisitor" name="addressCountry">
 							<lookup in="country-map" />
@@ -192,7 +192,7 @@
 						<data source="localityVisitor" name="type">
 							<constant value="http://schema.org/PostalAddress" />
 						</data>
-						<data source="plz" name="type">
+						<data source="str" name="type">
 							<not-equals string="NULL"/>
 							<constant value="http://schema.org/PostalAddress" />
 						</data>


### PR DESCRIPTION
The solution to issue #49 and #50 was:
- Setup a geodata microsoervice (not included here)
- Make use of it in the metafacture pipe via RestMap

The fix comprised in the other commit is not directly connected to this issue. It makes that there is 1 single TripleRematch object in the entire pipe and it would have occured anyway. Not sure, why it occured. Looks very similar to the one we had using TripleSort. Eventually we had a pull from culturegraph/metafacture which changed some of the memory behaviour? Anyway, the problem is solved now.