### PR TITLE
Rename output field 'ema' to 'email' for DBS entries (#84)

### DIFF
--- a/src/main/resources/morph-enriched.xml
+++ b/src/main/resources/morph-enriched.xml
@@ -120,7 +120,7 @@
 			<data source="email" name="email">
 				<regexp match="(.*)" format="mailto:${1}" />
 			</data>
-			<data source="ema">
+			<data source="ema" name="email">
 				<regexp match="(.*)" format="mailto:${1}" />
 			</data>
 		</choose>

--- a/src/test/resources/test_morph-enriched.xml
+++ b/src/test/resources/test_morph-enriched.xml
@@ -12,6 +12,9 @@
 						<literal name="035E.h" value="10" />
 						<literal name="gro_text" value="1.000.001 und mehr" />
 					</record>
+					<record id="de-123">
+						<literal name="ema" value="some.one@example.com" />
+					</record>
 				</records>
 			</cgxml>
 		</input>
@@ -34,6 +37,9 @@
 							<literal name="id" value="http://purl.org/lobid/stocksize#n10" />
 							<literal name="value" value="1.000.001 und mehr" />
 						</entity>
+					</record>
+					<record id="de-123">
+						<literal name="email" value="mailto:some.one@example.com" />
 					</record>
 				</records>
 			</cgxml>


### PR DESCRIPTION
Simply rename field from DBS dump abbreviation to its destinated name.