### PR TITLE
Make external service usage optional via command line args

### DIFF
--- a/src/main/java/flow/Constants.java
+++ b/src/main/java/flow/Constants.java
@@ -50,10 +50,4 @@ public class Constants {
 					.put("client.transport.ping_timeout", 20, TimeUnit.SECONDS).build());
 	protected static final Client ES_CLIENT = TC.addTransportAddress(NODE_1);
 
-	// GEO DATA LOOKUP
-	protected static final String GEO_SERVER_NAME = "localhost"; // "gaia.hbz-nrw.de";
-	protected static final String GEO_SERVER_PORT = "7400";
-	protected static final String GEO_INDEX_TEST = "geodata";
-	protected static final String GEO_TYPE = "geodata";
-
 }

--- a/src/main/java/flow/EnrichSample.java
+++ b/src/main/java/flow/EnrichSample.java
@@ -1,6 +1,7 @@
 package flow;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import org.culturegraph.mf.stream.converter.StreamToTriples;
 import org.culturegraph.mf.stream.pipe.CloseSupressor;
@@ -57,7 +58,7 @@ public class EnrichSample {
 		final StreamToTriples dbsFlow = //
 				Dbs.morphDbs(openDbs).setReceiver(Helpers.createTripleStream(true));
 		Helpers.setupTripleStreamToWriter(dbsFlow, wait, sortTriples,
-				rematchTriples, aOutputPath);
+				rematchTriples, aOutputPath, Optional.empty());
 		Dbs.processDbs(openDbs, DBS_LOCATION);
 
 		// Sigel Morph
@@ -65,7 +66,7 @@ public class EnrichSample {
 		StreamToTriples sigelFlow = Sigel.setupSigelMorph(splitFileOpener)
 				.setReceiver(Helpers.createTripleStream(true));
 		Helpers.setupTripleStreamToWriter(sigelFlow, wait, sortTriples,
-				rematchTriples, aOutputPath);
+				rematchTriples, aOutputPath, Optional.empty());
 		Sigel.processSigelMorph(splitFileOpener, SIGEL_TEMP_FILES_LOCATION);
 	}
 

--- a/src/test/java/flow/TestGeoEnrich.java
+++ b/src/test/java/flow/TestGeoEnrich.java
@@ -16,6 +16,8 @@ import org.junit.Test;
 @SuppressWarnings("javadoc")
 public class TestGeoEnrich extends ElasticsearchTest {
 
+	private static final String GEO_INDEX_TEST = "geodata";
+
 	private static SearchResponse searchByAddress(final String aIndex,
 			final Client aClient, final String aType, SearchType aSearchType,
 			QueryBuilder aQuery) {
@@ -40,8 +42,7 @@ public class TestGeoEnrich extends ElasticsearchTest {
 
 	private static SearchResponse searchByAddressInGeodata() {
 		QueryStringQueryBuilder query = QueryBuilders.queryString("Grabenstr. 4");
-		return searchByAddress(Constants.GEO_INDEX_TEST, geoClient, null, null,
-				query);
+		return searchByAddress(GEO_INDEX_TEST, geoClient, null, null, query);
 	}
 
 	@Test
@@ -56,8 +57,8 @@ public class TestGeoEnrich extends ElasticsearchTest {
 	public void testDbsGeoEnrichment() throws InterruptedException {
 		// wait for Geo Index to be set up
 		int count = 0;
-		while (!geoClient.admin().indices().prepareExists(Constants.GEO_INDEX_TEST)
-				.execute().actionGet().isExists()) {
+		while (!geoClient.admin().indices().prepareExists(GEO_INDEX_TEST).execute()
+				.actionGet().isExists()) {
 			Thread.sleep(1000);
 			count++;
 			if (count > 30) {
@@ -65,20 +66,9 @@ public class TestGeoEnrich extends ElasticsearchTest {
 			}
 		}
 		SearchHit responseGeoIndex = searchByAddressInGeodata().getHits().getAt(0);
-		assertTrue("Response should contain the field location",
+		assertTrue("Response should contain the geo location field",
 				responseGeoIndex.getSourceAsString().contains("geocode"));
-
-		// check geo information was processed while transforming organisation data
-		/* TODO: currently not set up for clean tests (no geodata service running)
-		SearchHit responseOrganisationsIndex =
-				searchByAddressInOrganisations("Grabenstr. 4").getHits().getAt(0);
-		assertTrue("Response should contain the field location",
-				responseOrganisationsIndex.getSourceAsString().contains("geo"));
-		assertTrue("Response should contain latitude",
-				responseOrganisationsIndex.getSourceAsString().contains("lat"));
-		assertTrue("Response should contain longitude",
-				responseOrganisationsIndex.getSourceAsString().contains("lon"));
-		*/
+		// TODO: test actual content of "geocode" field
 	}
 
 }


### PR DESCRIPTION
Resolves #119

Deployment note: with currently deployed parameter setup the behavior changes to skip remote geo lookup with these changes. After deployed to weywot2, update parameters in weywot1's cron to pass the additional `"http://gaia.hbz-nrw.de:7400"` parameter.