### PR TITLE
Remove whitespace from url and provides fields

### DIFF
--- a/app/transformation/morph-enriched.xml
+++ b/app/transformation/morph-enriched.xml
@@ -2,6 +2,38 @@
 <metamorph xmlns="http://www.culturegraph.org/metamorph"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1"
 	entityMarker=".">
+	<macros>
+		<!-- url and provides: Handle urls without http:// or https:// and remove blanks -->
+		<macro name="url-group">
+			<group name="$[group_name]">
+				<choose>
+					<data source="$[dbs_field]">
+						<regexp match="http(.*)" />
+						<replace pattern="\s+" with=""/>
+					</data>
+					<data source="$[dbs_field]">
+						<regexp match="(www(.*))" format="http://${1}"/>
+						<replace pattern="\s+" with=""/>
+					</data>
+					<combine value="${hp}" name="$[group_name]" sameEntity="true">
+						<choose>
+							<data source="009Q.u" name="hp">
+								<regexp match="http(.*)" />
+								<replace pattern="\s+" with=""/>
+							</data>
+							<data source="009Q.u" name="hp">
+								<regexp match="(www(.*))" format="http://${1}"/>
+								<replace pattern="\s+" with=""/>
+							</data>
+						</choose>
+						<data source="009Q.z" name="">
+							<regexp match="$[sigel_code]" format="" />
+						</data>
+					</combine>
+				</choose>
+			</group>
+		</macro>
+	</macros>
 	<rules>		
 		<data source="nam|029A.a" name="\@context">
 			<constant value="http://beta.lobid.org/organisations/context.jsonld" />
@@ -39,53 +71,9 @@
 			</choose>
 		</group>
 		
-		<!-- url and provides: Handle urls without http:// or https:// -->
-		<group name="url">
-			<choose>
-				<data source="url">
-					<regexp match="http(.*)" />
-				</data>
-				<data source="url">
-					<regexp match="(www(.*))" format="http://${1}"/>
-				</data>
-				<combine value="${hp}" name="url" sameEntity="true">
-					<choose>
-						<data source="009Q.u" name="hp">
-							<regexp match="http(.*)" />
-						</data>
-						<data source="009Q.u" name="hp">
-							<regexp match="(www(.*))" format="http://${1}"/>
-						</data>
-					</choose>
-					<data source="009Q.z" name="">
-						<regexp match="A" format="" />
-					</data>
-				</combine>
-			</choose>
-		</group>
-		<group name="provides">
-			<choose>
-				<data source="opa">
-					<regexp match="http(.*)" />
-				</data>
-				<data source="opa">
-					<regexp match="(www(.*))" format="http://${1}"/>
-				</data>
-				<combine value="${url}" name="provides" sameEntity="true">
-					<choose>
-						<data source="009Q.u" name="url">
-							<regexp match="http(.*)" />
-						</data>
-						<data source="009Q.u" name="url">
-							<regexp match="(www(.*))" format="http://${1}"/>
-						</data>
-					</choose>
-					<data source="009Q.z" name="">
-						<regexp match="B" format="" />
-					</data>
-				</combine>
-			</choose>
-		</group>
+		<call-macro name="url-group" group_name="url" dbs_field="url" sigel_code="A"/>
+		<call-macro name="url-group" group_name="provides" dbs_field="opa" sigel_code="B"/>
+		
 		<data source="isil" name="isil"/>
 		<data source="inr" name="dbsID"/>
 		<!-- new-id: isil if available or Pseudo-isil for DBS data that lack isil-->

--- a/test/transformation/test_morph-enriched.xml
+++ b/test/transformation/test_morph-enriched.xml
@@ -16,18 +16,24 @@
 						<literal name="035E.f" value="33" />
 						<literal name="035E.g" value="02" />
 						<literal name="035E.h" value="10" />
+						<literal name="009Q.u" value="http: //example.org /opac" />
+						<literal name="009Q.z" value="B" />
 					</record>
 					<record id="de-10">
 						<literal name="typ_text" value="Öffentliche Bibliothek" />
 						<literal name="utr_text" value="Land" />
 						<literal name="gro_text" value="1.000.001 und mehr" />
 						<literal name="stk_2007" value="10510011011" />
+						<literal name="url" value="http: //example.org" />
+						<literal name="opa" value="http://example.org/ opac" />
 					</record>
 					<record id="de-123">
 						<literal name="ema" value="some.one@example.com" />
 						<literal name="tvw" value="-221" />
 						<literal name="tel" value="123" />
 						<literal name="stk_2007" value="100460000000" />
+						<literal name="009Q.u" value="http://example.org " />
+						<literal name="009Q.z" value="A" />
 					</record>
 				</records>
 			</cgxml>
@@ -54,6 +60,7 @@
 					</record>
 					<record id="de-789">
 						<!--<literal name="inr" value="dbs-id" />-->
+						<literal name="provides" value="http://example.org/opac" />
 						<entity name="classification">
 							<literal name="id" value="http://purl.org/lobid/libtype#n33" />
 							<literal name="label" value="Öffentliche Bibliothek" />
@@ -70,6 +77,8 @@
 					<record id="de-10">
 						<!--<literal name="inr" value="dbs-id" />-->
 						<literal name="rs" value="010510011011" />
+						<literal name="url" value="http://example.org" />
+						<literal name="provides" value="http://example.org/opac" />
 						<entity name="classification">
 							<literal name="id" value="http://purl.org/lobid/libtype#n33" />
 							<literal name="label" value="Öffentliche Bibliothek" />
@@ -89,6 +98,7 @@
 						<literal name="email" value="mailto:some.one@example.com" />
 						 -->
 						 <literal name="rs" value="100460000000" />
+						 <literal name="url" value="http://example.org" />
 					</record>
 				</records>
 			</cgxml>


### PR DESCRIPTION
Also extracts rules to a macro to avoid further duplication.

Will resolve #146.

@dr0i Please only `+1` after review, will merge myself during production deployment.