### PR TITLE
Set up ID analyzer for id and isil fields

### DIFF
--- a/conf/index-settings.json
+++ b/conf/index-settings.json
@@ -11,6 +11,10 @@
 					"lowercasesearch": {
 						"tokenizer": "standard", 
 						"filter": "lowercase"
+					},
+					"id": {
+						"tokenizer": "keyword",
+						"filter": "lowercase"
 					}
 				}, 
 				"tokenizer": {
@@ -43,7 +47,11 @@
 					}
 				}, 
 				"id": {
-					"index": "not_analyzed", 
+					"analyzer": "id",
+					"type": "string"
+				},
+				"isil": {
+					"analyzer": "id",
 					"type": "string"
 				}
 			}

--- a/test/index/ElasticsearchTest.java
+++ b/test/index/ElasticsearchTest.java
@@ -33,17 +33,6 @@ public abstract class ElasticsearchTest {
 		client.close();
 	}
 
-	public static SearchResponse exactSearch(final String aField,
-			final String aValue) {
-		final SearchResponse responseOfSearch =
-				client.prepareSearch(Application.CONFIG.getString("index.es.name"))
-						.setTypes(Application.CONFIG.getString("index.es.type"))
-						.setSearchType(SearchType.DFS_QUERY_AND_FETCH)
-						.setQuery(QueryBuilders.termQuery(aField, aValue)).execute()
-						.actionGet();
-		return responseOfSearch;
-	}
-
 	public static SearchResponse search(final String aField,
 			final String aValue) {
 		SearchResponse responseOfSearch =

--- a/test/index/TestJsonStructure.java
+++ b/test/index/TestJsonStructure.java
@@ -1,4 +1,5 @@
 package index;
+
 import static org.junit.Assert.assertEquals;
 
 import org.elasticsearch.action.search.SearchResponse;
@@ -10,13 +11,13 @@ public class TestJsonStructure extends ElasticsearchTest {
 	@Test
 	public void checkHashBangInIDs() {
 		final SearchResponse sr1 =
-				exactSearch("id", "http://beta.lobid.org/organisations/DE-38#!");
+				search("id", "http://beta.lobid.org/organisations/DE-38#!");
 		assertEquals("Request should return 1", 1, sr1.getHits().getTotalHits());
 		final SearchResponse sr2 =
-				exactSearch("id", "http://beta.lobid.org/organisations/DE-294#!");
+				search("id", "http://beta.lobid.org/organisations/DE-294#!");
 		assertEquals("Request should return 1", 1, sr2.getHits().getTotalHits());
 		final SearchResponse sr3 =
-				exactSearch("id", "http://beta.lobid.org/organisations/DE-1a#!");
+				search("id", "http://beta.lobid.org/organisations/DE-1a#!");
 		assertEquals("Request should return 1", 1, sr3.getHits().getTotalHits());
 	}
 }


### PR DESCRIPTION
Will resolve #131

Uses keyword tokenizer and lowercase filter to work with query string query's lowercasing. Update tests for tweaked behavior.