### PR TITLE
Handle multiple locations and postal address in organisation view

### DIFF
--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -278,11 +278,13 @@ public class Application extends Controller {
 
 	private static Result resultFor(String id, JsonNode json, String format) {
 		Map<String, Supplier<Result>> results = new HashMap<>();
-		results.put("html", () -> ok(
-				views.html.organisation.render(id, json, json.findValue("geo") != null))
-						.as("text/html; charset=utf-8"));
-		results.put("js", () -> ok(views.js.details_map.render(json.toString()))
-				.as("application/javascript; charset=utf-8"));
+		results.put("html",
+				() -> ok(views.html.organisation.render(id, json,
+						json.findValue("location") != null))
+								.as("text/html; charset=utf-8"));
+		results.put("js",
+				() -> ok(views.js.location_details.render(json.toString()))
+						.as("application/javascript; charset=utf-8"));
 		Supplier<Result> jsonSupplier =
 				() -> ok(prettyJsonOk(json)).as("application/json; charset=utf-8");
 		Supplier<Result> resultSupplier = results.get(format);

--- a/app/views/details_map.scala.js
+++ b/app/views/details_map.scala.js
@@ -8,60 +8,64 @@
 @string(value: JsValue) = { @value.asOpt[String].getOrElse("--") }
 
 @defining(Json.parse(json)) { parsedContent =>
-@defining(((parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq())(0), 
-           (parsedContent \ "name"),
+
+  @for((location, i) <- (parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).zipWithIndex) {
+
+    @defining(((parsedContent \ "name"),
            (parsedContent \ "classification" \ "id").as[String],
-           Application.CONFIG.getObject("organisation.icons"))) { case(location, name, classification, icons)  =>
+           Application.CONFIG.getObject("organisation.icons"))) { case(name, classification, icons)  =>
 
-var layer = L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
-    subdomains: '1234'
-});
-var center = new L.LatLng(50, 10)
-var map = new L.Map("organisations-map", {
-    center: center,
-    zoom: 5,
-    scrollWheelZoom: true,
-    attributionControl: false,
-    zoomControl: true
-});
-@if((location \ "geo" \ "lon").asOpt[String].isDefined && (location \ "geo" \ "lat").asOpt[String].isDefined) {
-
-    var lat = @string((location \ "geo" \ "lat"))
-    var lon = @string((location \ "geo" \ "lon"))
-    var latlng = L.latLng(lat, lon);
-    var iconLabel = '@icons.getOrDefault(classification, ConfigValueFactory.fromAnyRef("library")).unwrapped()';
-    var icon = L.MakiMarkers.icon({icon: iconLabel, color: "#FF333B", size: "m"});
-    var marker = L.marker([lat, lon],{
-        title: "@string(name)",
-        icon: icon
-    });
-
-    locationDetails = "<table class='table table-striped table-condensed'>" 
+      locationDetails = "<table class='table table-striped table-condensed'>"
         + "<tr><td>Straße</td><td>@string((location \ "address" \ "streetAddress"))</td></tr>"
         + "<tr><td>Postleitzahl</td><td>@string((location \ "address" \ "postalCode"))</td></tr>"
         + "<tr><td>Stadt</td><td>@string((location \ "address" \ "addressLocality"))</td></tr>"
         + "<tr><td>Land</td><td>@string((location \ "address" \ "addressCountry"))</td></tr>"
         + "<tr><td>Öffnungzeiten</td><td>@string((location \ "openingHoursSpecification" \ "description"))</td></tr>"
         + "</table>";
-    bindPopup(locationDetails);
-    marker.addTo(map);
-    bindPopup(locationDetails);
-    zoomDetails();
-    marker.on('click', function(e) {
+
+      @if((location \ "geo" \ "lon").asOpt[String].isDefined && (location \ "geo" \ "lat").asOpt[String].isDefined) {
+	    var layer = L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
+	      subdomains: '1234'
+	    });
+	    var center = new L.LatLng(50, 10)
+	    var map = new L.Map("organisations-map@i", {
+	      center: center,
+	      zoom: 5,
+	      scrollWheelZoom: true,
+	      attributionControl: false,
+	      zoomControl: true
+	    });
+        var lat = @string((location \ "geo" \ "lat"))
+        var lon = @string((location \ "geo" \ "lon"))
+        var latlng = L.latLng(lat, lon);
+        var iconLabel = '@icons.getOrDefault(classification, ConfigValueFactory.fromAnyRef("library")).unwrapped()';
+        var icon = L.MakiMarkers.icon({icon: iconLabel, color: "#FF333B", size: "m"});
+        var marker = L.marker([lat, lon],{
+          title: "@string(name)",
+          icon: icon
+        });
+        bindPopup(locationDetails);
+        marker.addTo(map);
+        bindPopup(locationDetails);
         zoomDetails();
-    });
-    
-    function bindPopup(content) {
-       marker.bindPopup(
-           content,
-       {
-           keepInView: true,
-           
-       });
+        marker.on('click', function(e) {
+          zoomDetails();
+        });
+        function bindPopup(content) {
+          marker.bindPopup(
+            content,
+          {
+            keepInView: true,
+          });
+        }
+        function zoomDetails() {
+          map.setView(latlng, 16);
+          marker.openPopup();
+        }
+        map.addLayer(layer);
+      } else {
+	    document.getElementById("organisations-map@i").innerHTML = locationDetails;
+      }
     }
-    function zoomDetails() {
-        map.setView(latlng, 16);
-        marker.openPopup();
-    }
-    map.addLayer(layer);
-}}}
+  }
+}

--- a/app/views/details_map.scala.js
+++ b/app/views/details_map.scala.js
@@ -24,48 +24,61 @@
         + "</table>";
 
       @if((location \ "geo" \ "lon").asOpt[String].isDefined && (location \ "geo" \ "lat").asOpt[String].isDefined) {
-	    var layer = L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
-	      subdomains: '1234'
-	    });
-	    var center = new L.LatLng(50, 10)
-	    var map = new L.Map("organisations-map@i", {
-	      center: center,
-	      zoom: 5,
-	      scrollWheelZoom: true,
-	      attributionControl: false,
-	      zoomControl: true
-	    });
         var lat = @string((location \ "geo" \ "lat"))
         var lon = @string((location \ "geo" \ "lon"))
-        var latlng = L.latLng(lat, lon);
         var iconLabel = '@icons.getOrDefault(classification, ConfigValueFactory.fromAnyRef("library")).unwrapped()';
-        var icon = L.MakiMarkers.icon({icon: iconLabel, color: "#FF333B", size: "m"});
-        var marker = L.marker([lat, lon],{
-          title: "@string(name)",
-          icon: icon
-        });
-        bindPopup(locationDetails);
-        marker.addTo(map);
-        bindPopup(locationDetails);
-        zoomDetails();
-        marker.on('click', function(e) {
-          zoomDetails();
-        });
-        function bindPopup(content) {
-          marker.bindPopup(
-            content,
-          {
-            keepInView: true,
-          });
-        }
-        function zoomDetails() {
-          map.setView(latlng, 16);
-          marker.openPopup();
-        }
-        map.addLayer(layer);
+        var name = "@string(name)"
+        makeMap(@i, lat, lon, iconLabel, name, locationDetails);
       } else {
-	    document.getElementById("organisations-map@i").innerHTML = locationDetails;
+	    document.getElementById("organisations-map@i").innerHTML = "<h3>Standortadresse</h3>" + locationDetails;
       }
     }
   }
 }
+
+  function makeMap(i, latCoord, lonCoord, iconLabel, name, locationDetails) {
+    var layer = L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
+      subdomains: '1234'
+    });
+    var center = new L.LatLng(latCoord, lonCoord)
+    var map = new L.Map("organisations-map" + i, {
+     center: center,
+     zoom: 5,
+     scrollWheelZoom: true,
+     attributionControl: false,
+     zoomControl: true
+    });
+    var latlng = L.latLng(latCoord, lonCoord);
+    var icon = L.MakiMarkers.icon({icon: iconLabel, color: "#FF333B", size: "m"});
+    var marker = L.marker([latCoord, lonCoord],{
+      title: name,
+      icon: icon
+    });
+    marker.addTo(map);
+    bindPopup(locationDetails, marker);
+    zoomDetails(map, latlng, marker);
+    marker.on('click', function(e) {
+      zoomDetails(map, latlng, marker);
+   });
+   $(document).ready(function(){
+       $('.nav-tabs a').on('shown.bs.tab', function(event){
+           map.invalidateSize(false);
+           bindPopup(locationDetails, marker);
+           zoomDetails(map, latlng, marker)
+       });
+     });
+   map.addLayer(layer);
+  }
+
+  function bindPopup(content, marker) {
+    marker.bindPopup(
+      content,
+    {
+      keepInView: true,
+    });
+  }
+  function zoomDetails(map, latlng, marker) {
+	map.invalidateSize(false);
+    map.setView(latlng, 16);
+    marker.openPopup();
+  }

--- a/app/views/location_details.scala.js
+++ b/app/views/location_details.scala.js
@@ -30,7 +30,7 @@
         var name = "@string(name)"
         makeMap(@i, lat, lon, iconLabel, name, locationDetails);
       } else {
-	    document.getElementById("organisations-map@i").innerHTML = "<h3>Standortadresse</h3>" + locationDetails;
+	    document.getElementById("organisations-map@i").innerHTML = locationDetails;
       }
     }
   }
@@ -55,32 +55,19 @@ function makeMap(i, latCoord, lonCoord, iconLabel, name, locationDetails) {
     icon: icon
   });
   marker.addTo(map);
-  bindPopup(locationDetails, marker);
-  zoomDetails(map, latlng, marker);
+  zoomDetails(map, latlng, marker, locationDetails);
   marker.on('click', function(e) {
     zoomDetails(map, latlng, marker);
   });
-  $(document).ready(function(){
-    $('.nav-tabs a').on('shown.bs.tab', function(event){
-      map.invalidateSize(false);
-      bindPopup(locationDetails, marker);
-      zoomDetails(map, latlng, marker)
-    });
+  $('.nav-tabs a').on('shown.bs.tab', function(event){
+    zoomDetails(map, latlng, marker, locationDetails);
   });
   map.addLayer(layer);
  }
 
-function bindPopup(content, marker) {
-  marker.bindPopup(
-    content,
-  {
-    keepInView: true,
-    minWidth: 300
-  });
-}
-
-function zoomDetails(map, latlng, marker) {
+function zoomDetails(map, latlng, marker, content) {
   map.invalidateSize(false);
-  map.setView(latlng, 16);
+  marker.bindPopup(content, {keepInView: true, minWidth: 300});
+  map.setView(latlng, 16, {animate: false});
   marker.openPopup();
 }

--- a/app/views/location_details.scala.js
+++ b/app/views/location_details.scala.js
@@ -75,6 +75,7 @@ function bindPopup(content, marker) {
     content,
   {
     keepInView: true,
+    minWidth: 300
   });
 }
 

--- a/app/views/location_details.scala.js
+++ b/app/views/location_details.scala.js
@@ -36,49 +36,50 @@
   }
 }
 
-  function makeMap(i, latCoord, lonCoord, iconLabel, name, locationDetails) {
-    var layer = L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
-      subdomains: '1234'
-    });
-    var center = new L.LatLng(latCoord, lonCoord)
-    var map = new L.Map("organisations-map" + i, {
-     center: center,
-     zoom: 5,
-     scrollWheelZoom: true,
-     attributionControl: false,
-     zoomControl: true
-    });
-    var latlng = L.latLng(latCoord, lonCoord);
-    var icon = L.MakiMarkers.icon({icon: iconLabel, color: "#FF333B", size: "m"});
-    var marker = L.marker([latCoord, lonCoord],{
-      title: name,
-      icon: icon
-    });
-    marker.addTo(map);
-    bindPopup(locationDetails, marker);
+function makeMap(i, latCoord, lonCoord, iconLabel, name, locationDetails) {
+  var layer = L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
+    subdomains: '1234'
+  });
+  var center = new L.LatLng(latCoord, lonCoord)
+  var map = new L.Map("organisations-map" + i, {
+   center: center,
+   zoom: 5,
+   scrollWheelZoom: true,
+   attributionControl: false,
+   zoomControl: true
+  });
+  var latlng = L.latLng(latCoord, lonCoord);
+  var icon = L.MakiMarkers.icon({icon: iconLabel, color: "#FF333B", size: "m"});
+  var marker = L.marker([latCoord, lonCoord],{
+    title: name,
+    icon: icon
+  });
+  marker.addTo(map);
+  bindPopup(locationDetails, marker);
+  zoomDetails(map, latlng, marker);
+  marker.on('click', function(e) {
     zoomDetails(map, latlng, marker);
-    marker.on('click', function(e) {
-      zoomDetails(map, latlng, marker);
-   });
-   $(document).ready(function(){
-       $('.nav-tabs a').on('shown.bs.tab', function(event){
-           map.invalidateSize(false);
-           bindPopup(locationDetails, marker);
-           zoomDetails(map, latlng, marker)
-       });
-     });
-   map.addLayer(layer);
-  }
-
-  function bindPopup(content, marker) {
-    marker.bindPopup(
-      content,
-    {
-      keepInView: true,
+  });
+  $(document).ready(function(){
+    $('.nav-tabs a').on('shown.bs.tab', function(event){
+      map.invalidateSize(false);
+      bindPopup(locationDetails, marker);
+      zoomDetails(map, latlng, marker)
     });
-  }
-  function zoomDetails(map, latlng, marker) {
-	map.invalidateSize(false);
-    map.setView(latlng, 16);
-    marker.openPopup();
-  }
+  });
+  map.addLayer(layer);
+ }
+
+function bindPopup(content, marker) {
+  marker.bindPopup(
+    content,
+  {
+    keepInView: true,
+  });
+}
+
+function zoomDetails(map, latlng, marker) {
+  map.invalidateSize(false);
+  map.setView(latlng, 16);
+  marker.openPopup();
+}

--- a/app/views/organisation.scala.html
+++ b/app/views/organisation.scala.html
@@ -43,11 +43,13 @@
                       <li><a href="#organisations-map@i">Standort @(i+1)</a></li>
                     }
                   }
+                  @if(!(parsedContent \ "address").asOpt[JsObject].isDefined) {
+                    </ul>
+                  }
                 }
                 @if((parsedContent \ "address").asOpt[JsObject].isDefined) {
-                  <li><a href="#postal-address">Postadresse</a></li>
+                  <li><a href="#postal-address">Postadresse</a></li></ul>
                 }
-              </ul>
               <div class="tab-content">
                 @if((parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length > 1
                   || ((parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length == 1
@@ -80,8 +82,8 @@
               </div>
           </div>
         }
-      </div>
-    </p>
+        </div>
+      </p>
     }
 
     <script>

--- a/app/views/organisation.scala.html
+++ b/app/views/organisation.scala.html
@@ -1,15 +1,15 @@
-@(id: String, content: com.fasterxml.jackson.databind.JsonNode, hasGeoData: Boolean)
+@(id: String, content: com.fasterxml.jackson.databind.JsonNode, hasLocation: Boolean)
 
 @import play.api.libs.json._
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
 
-@main("", if(hasGeoData){makeMap()}else{Html("")}) {
+@main("", if(hasLocation){makeLocationDetails()}else{Html("")}) {
     <h1>@id</h1>
     @defining(Json.parse(content.toString())) { parsedContent =>
     <p>
       <div class="row">
-        <div class="col-md-@if(hasGeoData){6}else{12}">
+        <div class="col-md-@if(hasLocation){6}else{12}">
           <p>
           <table class='table table-striped table-condensed'>
               @produceRow("Name", parsedContent \ "name", false)
@@ -30,12 +30,12 @@
           </table>
           </p>
         </div>
-        @if(hasGeoData){
+        @if(hasLocation){
           <div class="col-md-6">
-              <ul class="nav nav-tabs">
                 @if((parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length > 1
                   || ((parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length == 1
                      && (parsedContent \ "address").asOpt[JsObject].isDefined)) {
+                  <ul class="nav nav-tabs">
                   @for(i <- 0 to (parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length-1) {
                     @if(i == 0) {
                       <li class="active"><a href="#organisations-map@i">Standort @(i+1)</a></li>
@@ -115,7 +115,7 @@
     }
 }
 
-@makeMap() = {
+@makeLocationDetails() = {
 <link rel="stylesheet" href='@controllers.routes.Assets.at("stylesheets/leaflet.css")' />
 <script src='@controllers.routes.Assets.at("javascripts/leaflet.js")'></script>
 <script src='@controllers.routes.Assets.at("javascripts/Leaflet.MakiMarkers.js")'></script>

--- a/app/views/organisation.scala.html
+++ b/app/views/organisation.scala.html
@@ -3,7 +3,6 @@
 @import play.api.libs.json._
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
-<script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
 
 @main("", if(hasGeoData){makeMap()}else{Html("")}) {
     <h1>@id</h1>
@@ -30,41 +29,55 @@
               }
           </table>
           </p>
-          @if((parsedContent \ "address").asOpt[JsObject].isDefined) {
-           <h3>Postanschrift</h3>
-           <p>
-           <table class='table table-striped table-condensed'>
-              @produceRow("Postfach", parsedContent \ "address" \ "postOfficeBoxNumber", false)
-              @produceRow("Postleitzahl", parsedContent \ "address" \ "postalCode", false)
-              @produceRow("Stadt", parsedContent \ "address" \ "addressLocality", false)
-           </table>
-           </p>
-          }
         </div>
         @if(hasGeoData){
           <div class="col-md-6">
-            @if((parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length > 1) {
               <ul class="nav nav-tabs">
-                @for(i <- 0 to (parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length-1) {
-                  @if(i == 0) {
-                    <li class="active"><a href="#organisations-map@i">Standort @(i+1)</a></li>
-                  } else {
-                    <li><a href="#organisations-map@i">Standort @(i+1)</a></li>
+                @if((parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length > 1
+                  || ((parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length == 1
+                     && (parsedContent \ "address").asOpt[JsObject].isDefined)) {
+                  @for(i <- 0 to (parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length-1) {
+                    @if(i == 0) {
+                      <li class="active"><a href="#organisations-map@i">Standort @(i+1)</a></li>
+                    } else {
+                      <li><a href="#organisations-map@i">Standort @(i+1)</a></li>
+                    }
                   }
+                }
+                @if((parsedContent \ "address").asOpt[JsObject].isDefined) {
+                  <li><a href="#postal-address">Postadresse</a></li>
                 }
               </ul>
               <div class="tab-content">
-                @for(i <- 0 to (parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length-1) {
-                  @if(i == 0) {
-                    <div id="organisations-map@i" class="tab-pane fade in active organisations-map"></div>
-                  } else {
-                    <div id="organisations-map@i" class="tab-pane fade"></div>
+                @if((parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length > 1
+                  || ((parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length == 1
+                     && (parsedContent \ "address").asOpt[JsObject].isDefined)) {
+                  @for(i <- 0 to (parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length-1) {
+                    @if(i == 0) {
+                      <div id="organisations-map@i" class="tab-pane fade in active organisations-map"></div>
+                    } else {
+                      <div id="organisations-map@i" class="tab-pane fade organisations-map"></div>
+                    }
                   }
-                 }
+                  @if((parsedContent \ "address").asOpt[JsObject].isDefined) {
+                     <div id="postal-address" class="tab-pane fade">
+                       <h3>Postadresse</h3>
+                       <p>
+                         <table class='table table-striped table-condensed'>
+                           @produceRow("Postfach", parsedContent \ "address" \ "postOfficeBoxNumber", false)
+                           @produceRow("Postleitzahl", parsedContent \ "address" \ "postalCode", false)
+                           @produceRow("Stadt", parsedContent \ "address" \ "addressLocality", false)
+                         </table>
+                       </p>
+                     </div>
+                  }
+                } else {
+                  <div id="organisations-map0" class="organisations-map"></div>
+                }
+                @if((parsedContent \ "address").asOpt[JsObject].isDefined) {
+                  <div id="postal-address" class="tab-pane fade">Display postal address</div>
+                }
               </div>
-            } else {
-              <div id="organisations-map0" class="organisations-map"></div>
-            }
           </div>
         }
       </div>
@@ -78,7 +91,7 @@
         });
       });
     </script>
-    
+
     <p>You can also access <a href='@routes.Application.get(id=id, format="json")'>this data</a> using our <a href="@routes.Application.api()">API</a>.</p>
     
 }

--- a/app/views/organisation.scala.html
+++ b/app/views/organisation.scala.html
@@ -2,6 +2,9 @@
 
 @import play.api.libs.json._
 
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
+<script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+
 @main("", if(hasGeoData){makeMap()}else{Html("")}) {
     <h1>@id</h1>
     @defining(Json.parse(content.toString())) { parsedContent =>
@@ -39,13 +42,42 @@
           }
         </div>
         @if(hasGeoData){
-        <div class="col-md-6">
-            <div id="organisations-map"></div>
-        </div>
+          <div class="col-md-6">
+            @if((parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length > 1) {
+              <ul class="nav nav-tabs">
+                @for(i <- 0 to (parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length-1) {
+                  @if(i == 0) {
+                    <li class="active"><a href="#organisations-map@i">Standort @(i+1)</a></li>
+                  } else {
+                    <li><a href="#organisations-map@i">Standort @(i+1)</a></li>
+                  }
+                }
+              </ul>
+              <div class="tab-content">
+                @for(i <- 0 to (parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length-1) {
+                  @if(i == 0) {
+                    <div id="organisations-map@i" class="tab-pane fade in active organisations-map"></div>
+                  } else {
+                    <div id="organisations-map@i" class="tab-pane fade"></div>
+                  }
+                 }
+              </div>
+            } else {
+              <div id="organisations-map0" class="organisations-map"></div>
+            }
+          </div>
         }
       </div>
     </p>
     }
+
+    <script>
+      $(document).ready(function(){
+        $(".nav-tabs a").click(function(){
+          $(this).tab('show');
+        });
+      });
+    </script>
     
     <p>You can also access <a href='@routes.Application.get(id=id, format="json")'>this data</a> using our <a href="@routes.Application.api()">API</a>.</p>
     

--- a/app/views/organisation.scala.html
+++ b/app/views/organisation.scala.html
@@ -2,8 +2,6 @@
 
 @import play.api.libs.json._
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
-
 @main("", if(hasLocation){makeLocationDetails()}else{Html("")}) {
     <h1>@id</h1>
     @defining(Json.parse(content.toString())) { parsedContent =>
@@ -38,9 +36,9 @@
                   <ul class="nav nav-tabs">
                   @for(i <- 0 to (parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length-1) {
                     @if(i == 0) {
-                      <li class="active"><a href="#organisations-map@i">Standort @(i+1)</a></li>
+                      <li class="active"><a href="#organisations-map@i" data-toggle="tab">Standort @(i+1)</a></li>
                     } else {
-                      <li><a href="#organisations-map@i">Standort @(i+1)</a></li>
+                      <li><a href="#organisations-map@i" data-toggle="tab">Standort @(i+1)</a></li>
                     }
                   }
                   @if(!(parsedContent \ "address").asOpt[JsObject].isDefined) {
@@ -48,7 +46,7 @@
                   }
                 }
                 @if((parsedContent \ "address").asOpt[JsObject].isDefined) {
-                  <li><a href="#postal-address">Postadresse</a></li></ul>
+                  <li><a href="#postal-address" data-toggle="tab">Postadresse</a></li></ul>
                 }
               <div class="tab-content">
                 @if((parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length > 1
@@ -56,14 +54,13 @@
                      && (parsedContent \ "address").asOpt[JsObject].isDefined)) {
                   @for(i <- 0 to (parsedContent \ "location").asOpt[Seq[JsValue]].getOrElse(Seq()).length-1) {
                     @if(i == 0) {
-                      <div id="organisations-map@i" class="tab-pane fade in active organisations-map"></div>
+                      <div id="organisations-map@i" class="tab-pane active organisations-map"></div>
                     } else {
-                      <div id="organisations-map@i" class="tab-pane fade organisations-map"></div>
+                      <div id="organisations-map@i" class="tab-pane organisations-map"></div>
                     }
                   }
                   @if((parsedContent \ "address").asOpt[JsObject].isDefined) {
-                     <div id="postal-address" class="tab-pane fade">
-                       <h3>Postadresse</h3>
+                     <div id="postal-address" class="tab-pane">
                        <p>
                          <table class='table table-striped table-condensed'>
                            @produceRow("Postfach", parsedContent \ "address" \ "postOfficeBoxNumber", false)
@@ -86,16 +83,8 @@
       </p>
     }
 
-    <script>
-      $(document).ready(function(){
-        $(".nav-tabs a").click(function(){
-          $(this).tab('show');
-        });
-      });
-    </script>
-
     <p>You can also access <a href='@routes.Application.get(id=id, format="json")'>this data</a> using our <a href="@routes.Application.api()">API</a>.</p>
-    
+
 }
 
 @produceRow(name: String, value: JsValue, link: Boolean) = {

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -43,6 +43,7 @@ td.field-value {
 	width: 100%;
 	height: 400px
 }
+
 select {
 	max-width: 110px;
 }
@@ -59,5 +60,4 @@ select {
 
 .table-striped {
 	margin-top: 20px;
-}
 }

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -39,7 +39,7 @@ td.field-value {
 	width: 75%;
 }
 
-#organisations-map {
+.organisations-map {
 	width: 100%;
 	height: 400px
 }

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -61,3 +61,7 @@ select {
 .table-striped {
 	margin-top: 20px;
 }
+
+* {
+    font-size: 14px;
+}


### PR DESCRIPTION
Handle multiple locations and postal address in different tabs such that:
* multiple maps are displayed when geo data is available for the location
* address table is displayed in that tab if NO geo data is available
* postal address is shown is separate tab if available
* no tab layout is shown if only ONE information can be displayed (either one map or one address table for a location or -- no test case found -- the postal address alone)

Will resolve #210 