### PR TITLE
Validate DBS ID format in Sigel data

### DIFF
--- a/app/transformation/morph-sigel.xml
+++ b/app/transformation/morph-sigel.xml
@@ -11,6 +11,7 @@
 		<choose>
 			<data name="_id" source="008H.b">
 				<replace  pattern=" "  with=""/>
+				<regexp match="[A-Z]{2}\d{3}"/>
 			</data>
 			<data name="_id" source="008H.e">
 				<replace  pattern=" "  with=""/>
@@ -19,6 +20,7 @@
 
 		<data name="inr" source="008H.b">
 			<replace  pattern=" "  with=""/>
+			<regexp match="[A-Z]{2}\d{3}"/>
 		</data>
 		<data name="isil" source="008H.e">
 			<replace  pattern=" "  with=""/>

--- a/test/transformation/test_morph-sigel.xml
+++ b/test/transformation/test_morph-sigel.xml
@@ -6,7 +6,7 @@
 			<cgxml version="1.0" xmlns="http://www.culturegraph.org/cgxml">
 				<records>
 					<record id="1">
-						<literal name="008H.b" value="qvw741" />
+						<literal name="008H.b" value="QV174" />
 						<literal name="008H.e" value="de-456" />
 					</record>
 					<record id="2">
@@ -21,9 +21,9 @@
 			<cgxml version="1.0" xmlns="http://www.culturegraph.org/cgxml">
 				<records>
 					<record id="1">
-						<literal name="inr" value="qvw741" />
+						<literal name="inr" value="QV174" />
 						<literal name="isil" value="de-456" />
-						<literal name="_id" value="qvw741" />
+						<literal name="_id" value="QV174" />
 					</record>
 					<record id="2">
 						<literal name="isil" value="de-456" />


### PR DESCRIPTION
DBS ID must be made of two capital letters followed by three digits

Will resolve #237