### PR TITLE
Show German type labels in search and details

### DIFF
--- a/app/views/organisation.scala.html
+++ b/app/views/organisation.scala.html
@@ -105,7 +105,7 @@
                   </td>
                   <td class="field-value">
                       @if(!link(valueAsString).isDefined) {
-                          @valueAsString
+                          @if(name=="Typ" && Application.currentLang()=="de"){@Application.CONFIG.getString("organisation.types." + valueAsString)} else {@valueAsString}
                       } else {
                           <a href="@valueAsString">@link(valueAsString).get</a>
                       }

--- a/app/views/search.scala.html
+++ b/app/views/search.scala.html
@@ -5,16 +5,21 @@
 @import play.api.libs.json._
 @import com.typesafe.config._
 @import play.i18n._
+@import controllers.Application
+
+@localized(term: String, key: String) = {
+  @if(key=="type" && Application.currentLang()=="de"){@Application.CONFIG.getString("organisation.types."+term)} else {@term}
+}
 
 @links(buckets: Seq[JsValue], key: String) = {
 	@for(bucket <- buckets; term = (bucket \ "key").as[String]; count = (bucket \ "doc_count").as[Int]) {
 		@if(q.contains(key+":\""+term+"\"")){
-		@term
+		@localized(term, key)
 		<a href='@routes.Application.search()?location=@location&from=@from&size=@size&q=@q.replace("AND "+key+":\""+term+"\"","").trim'>
 		<span class="badge">@Messages.get("search.remove_filter") <span class="glyphicon glyphicon-remove"></span></span>
 		</a>
 		} else {
-		<a href='@routes.Application.search()?location=@location&from=@from&size=@size&q=@q.trim+AND+@key:"@term"'>@term (@count)</a>
+		<a href='@routes.Application.search()?location=@location&from=@from&size=@size&q=@q.trim+AND+@key:"@term"'>@localized(term, key) (@count)</a>
 		}<br/>
 	}
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -111,3 +111,11 @@ organisation.icons={
   "http://purl.org/lobid/libtype#n82" : "monument",
   "http://purl.org/lobid/libtype#n86" : "museum"
 }
+
+organisation.types={
+  "Library" : "Bibliothek",
+  "Museum" : "Museum",
+  "Archive" : "Archiv",
+  "Organization" : "Sonstige",
+  "Publisher" : "Verlag"
+}


### PR DESCRIPTION
Will resolve #297

See:

http://test.lobid.org/organisations/search (`Typ` facet in German version)
http://test.lobid.org/organisations/DE-2382 (`Typ` field in German version)