### PR TITLE
Add dataset description with about.jsonld.

### DIFF
--- a/conf/about.jsonld
+++ b/conf/about.jsonld
@@ -11,7 +11,6 @@
       "@id": "http://purl.org/dc/elements/1.1/rights",
       "@container": "@language"
       },
-    "dcat": "http://www.w3.org/ns/dcat#",
     "label": {
       "@id": "http://www.w3.org/2000/01/rdf-schema#label",
       "@container": "@language"

--- a/conf/about.jsonld
+++ b/conf/about.jsonld
@@ -1,0 +1,104 @@
+{
+  "@context": {
+    "id": "@id",
+    "type": "@type",
+    "@vocab": "http://schema.org/",
+    "accrualPeriodicity": {
+      "@id": "http://purl.org/dc/terms/accrualPeriodicity",
+      "@type": "@id"
+      },
+    "rights": {
+      "@id": "http://purl.org/dc/elements/1.1/rights",
+      "@container": "@language"
+      },
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "label": {
+      "@id": "http://www.w3.org/2000/01/rdf-schema#label",
+      "@container": "@language"
+    },
+    "description": {
+      "@container": "@language"
+    },
+    "Distribution": "http://www.w3.org/ns/dcat#Distribution",
+    "accessURL": "http://www.w3.org/ns/dcat#accessURL",
+    "mediaType": "http://www.w3.org/ns/dcat#mediaType"
+  },
+  "id": "http://lobid.org/organisations#!",
+  "type": "Dataset",
+  "name": "lobid-organisations",
+  "description": {
+    "de": "<p>lobid-organisations ist ein umfassendes Verzeichnis von etwa 30.000 Bibliotheken und verwandten Einrichtungen im deutschsprachigen Raum. Die Daten werden in einem strukturierten Format (JSON-LD) über eine webbasierte Programmierschnittstelle (API) mit einer intuitiven Benutzeroberfläche bereitgestellt. Vielfältige Möglichkeiten der Datenabfrage werden unterstützt.</p><p>Die Datenquellen dieses Dienstes sind das <a href=\"http://sigel.staatsbibliothek-berlin.de\">Deutsche ISIL-Verzeichnis</a> und die Stammdaten der <a href=\"https://www.hbz-nrw.de/produkte/bibliotheksstatistik\">Deutschen Bibliotheksstatistik (DBS)</a>.</p>",
+    "en": "<p>lobid-organisations ia a comprehensive directory of approximately 30,000 libraries, archives and museums in German-speaking countries. The data is provided as structured data (JSON-LD) via a web API with an intuitive user interface on top. Multiple options for querying the data are supported.</p><p>The source data sets for this service are the <a href=\"http://sigel.staatsbibliothek-berlin.de\">German ISIL registry</a> and the base data from the <a href=\"https://www.hbz-nrw.de/produkte/bibliotheksstatistik\">German Library Statistics (DBS)</a>.</p>"
+  },
+  "keywords": [
+    "libraries",
+    "archives",
+    "museums",
+    "locations",
+    "addresses"
+  ],
+  "spatial": [
+    {
+      "id": "http://www.wikidata.org/entity/Q183",
+      "label": {
+        "de": "Deutschland",
+        "en": "Germany"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/Q39",
+      "label": {
+        "de": "Schweiz",
+        "en": "Switzerland"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/Q40",
+      "label": {
+        "de": "Österreich",
+        "en": "Austria"
+      }
+    }
+  ],
+  "datePublished": "2017-03-31",
+  "contactPoint": "http://lobid.org/contact",
+  "accrualPeriodicity": {
+    "id": "http://purl.org/linked-data/sdmx/2009/code#freq-B",
+    "label": {
+      "en": "Daily - business week",
+      "de": "Täglich (werktags)"
+    }
+  },
+  "inLanguage": [
+    "de",
+    "en"
+  ],
+  "publisher": {
+    "id": "http://lobid.org/organisations/DE-605#!",
+    "label": {
+      "de": "Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen",
+      "en": "North Rhine-Westphalian Library Service"
+    },
+    "alternateName": [
+      "hbz"
+    ]
+  },
+  "distribution": [
+    {
+      "id": "http://lobid.org/organisations/search",
+      "type": "Distribution",
+      "label": "lobid-organisations API",
+      "description": "The API gives access to machine-readable data. For documentation see http://lobid.org/organisations/api.",
+      "accessURL": "http://lobid.org/organisations/search",
+      "mediaType": [
+        "text/csv",
+        "application/json",
+        "application/ld+json"
+      ],
+      "rights": {
+          "en": "The source data sets currently don't fully fall under an open license. While the ISIL data are <a href=\"http://www.dnb.de/dataservice\">available</a> from the German National Library (DNB) under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>, the DBS data is currently not openly licensed. Thus, unfortunately lobid-organisations data can n ot be provided under an open license yet.",
+          "de": "Die Quelldaten sind derzeit leider nicht vollständig offen lizenziert. Zwar werden die ISIL-Daten werden von der Deutschen Nationalbibliothek (DNB) unter einer <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>-Lizenz <a href=\"http://www.dnb.de/datendienst\">bereitgestellt</a>, für die DBS-Stammdaten gibt es derzeit aber keine offene Lizenzierung. Somit können die lobid-organisations-Daten leider noch nicht mit einer offenen Lizenz versehen werden."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
See https://github.com/hbz/lobid-organisations/issues/255

As one can see, this file contains information from http://lobid.org/organisations. I would like to revisit my suggestion from #278 . I think it would make sense to move the description to an about page (with embedded JSON-LD) and don't show that much text on the home page...