### PR TITLE
Adjust English classification label for n86

### DIFF
--- a/conf/morph-enriched.xml
+++ b/conf/morph-enriched.xml
@@ -526,7 +526,7 @@
 			<entry name="http://purl.org/lobid/libtype#n81" value="Academic Special Library" />
 			<entry name="http://purl.org/lobid/libtype#n82" value="Institution for Preservation of Historical Monuments" />
 			<entry name="http://purl.org/lobid/libtype#n84" value="Research Institution" />
-			<entry name="http://purl.org/lobid/libtype#n86" value="Museum (not Museum Library)" />
+			<entry name="http://purl.org/lobid/libtype#n86" value="Museum" />
 			<entry name="http://purl.org/lobid/libtype#n87" value="Publisher" />
 			<entry name="http://purl.org/lobid/libtype#n88" value="Other Organization" />
 			<entry name="http://purl.org/lobid/libtype#n89" value="Collection of electronic resources" />


### PR DESCRIPTION
Following the changes in the vocab at https://github.com/hbz/lobid-vocabs/issues/60. (Forgot the English label, only changed the German one in #325 .