### PR TITLE
Adjust dataset description to follow W3C recommendation

### DIFF
--- a/conf/dataset.jsonld
+++ b/conf/dataset.jsonld
@@ -21,6 +21,7 @@
     "description": {
       "@container": "@language"
     },
+    "distribution": "http://www.w3.org/ns/dcat#distribution",
     "Distribution": "http://www.w3.org/ns/dcat#Distribution",
     "accessURL": "http://www.w3.org/ns/dcat#accessURL",
     "mediaType": "http://www.w3.org/ns/dcat#mediaType"


### PR DESCRIPTION
Just a small change. We should use `dcat:distribution` rather than `schema:distribution` because

1. it is recommended by https://www.w3.org/TR/dwbp/#metadata
2. it better fits our use case as `schema:distribution` let's you rather expect a downloadable data dump (from the description: "A downloadable form of this dataset, at a specific location, in a specific format.")