### PR TITLE
373 improve logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-sudo: false
 language: java
 jdk: oraclejdk8
 env:
-  - ACTIVATOR_VERSION=1.3.10
+  - ACTIVATOR_VERSION=1.3.12
 before_install:
   - git clone https://github.com/hbz/metafacture-core.git
   - cd metafacture-core

--- a/app/Global.java
+++ b/app/Global.java
@@ -44,16 +44,20 @@ public class Global extends GlobalSettings {
 	private static void initData() {
 		try {
 			if (new File(Enrich.DATA_OUTPUT_FILE).exists()) {
-				Logger.info(
-						"Transformation output file exists, indexing only. "
-								+ "To trigger transformation on start, delete '{}'",
-						Enrich.DATA_OUTPUT_FILE);
-			} else {
-				Logger.info("Starting transformation, will write to '{}' ",
-						Enrich.DATA_OUTPUT_FILE);
-				Transformation.transformSet();
+				long minimumSize = Long.parseLong(
+						controllers.Application.CONFIG.getString("index.file.minsize"));
+				if (new File(Enrich.DATA_OUTPUT_FILE).exists()
+						&& new File(Enrich.DATA_OUTPUT_FILE).length() >= minimumSize) {
+					Logger.info(
+							"Transformation output file exists and file is greater than minimum size, indexing only. "
+									+ Enrich.DATA_OUTPUT_FILE);
+				} else {
+					Logger.info("Starting transformation, will write to '{}' ",
+							Enrich.DATA_OUTPUT_FILE);
+					Transformation.transformSet();
+				}
+				Index.initialize(Enrich.DATA_OUTPUT_FILE);
 			}
-			Index.initialize(Enrich.DATA_OUTPUT_FILE);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/app/controllers/Application.java
+++ b/app/controllers/Application.java
@@ -107,7 +107,7 @@ public class Application extends Controller {
 				});
 			}).recoverWith(t -> index());
 		} catch (Exception e) {
-			e.printStackTrace();
+			Logger.warn(e.getMessage(), e);
 			return Promise.pure(internalServerError(e.getMessage()));
 		}
 	}
@@ -300,7 +300,7 @@ public class Application extends Controller {
 					.readAllLines(Play.application().resourceAsStream(name + ".jsonld"))
 					.stream().collect(Collectors.joining("\n"));
 		} catch (IOException e) {
-			e.printStackTrace();
+			Logger.error("Couldn't get dataset", e);
 			return null;
 		}
 	}
@@ -326,8 +326,8 @@ public class Application extends Controller {
 					.containsAll(Arrays.asList(aggregations.split(",")))) {
 				return badRequest(
 						String.format("Unsupported aggregations: %s (supported: %s)",
-								aggregations.replace(".raw", ""), Index.SUPPORTED_AGGREGATIONS
-										.toString().replace(".raw", "")));
+								aggregations.replace(".raw", ""),
+								Index.SUPPORTED_AGGREGATIONS.toString().replace(".raw", "")));
 			}
 		}
 		final String responseFormat =
@@ -355,7 +355,7 @@ public class Application extends Controller {
 			Cache.set(cacheKey, searchResult, ONE_DAY);
 			return searchResult;
 		} catch (IllegalArgumentException x) {
-			x.printStackTrace();
+			Logger.warn("Bad request: ", x.getMessage());
 			return badRequest("Bad request: " + x.getMessage());
 		}
 	}
@@ -736,7 +736,7 @@ public class Application extends Controller {
 			return new ObjectMapper().writerWithDefaultPrettyPrinter()
 					.writeValueAsString(jsonNode);
 		} catch (JsonProcessingException x) {
-			x.printStackTrace();
+			Logger.warn(x.getMessage());
 			return null;
 		}
 	}

--- a/app/controllers/Transformation.java
+++ b/app/controllers/Transformation.java
@@ -4,6 +4,7 @@ package controllers;
 
 import java.io.IOException;
 
+import akka.event.slf4j.Logger;
 import play.mvc.Controller;
 import play.mvc.Result;
 import transformation.Enrich;
@@ -47,7 +48,7 @@ public class Transformation extends Controller {
 			Enrich.process(startOfUpdates, Integer.parseInt(intervalSize), outputPath,
 					geoLookupServer);
 		} catch (Exception e) {
-			e.printStackTrace();
+			Logger.root().error("Transformation failed", e);
 			return internalServerError("Transformation failed");
 		}
 		return ok("Transforming full data");

--- a/app/transformation/Enrich.java
+++ b/app/transformation/Enrich.java
@@ -21,6 +21,7 @@ import org.culturegraph.mf.stream.source.OaiPmhOpener;
 import org.culturegraph.mf.types.Triple;
 
 import controllers.Application;
+import play.Logger;
 
 /**
  * Simple enrichment of DBS records with Sigel data based on the DBS ID.
@@ -163,7 +164,7 @@ public class Enrich {
 			calender.add(Calendar.DATE, intervalSize);
 			result = dateFormat.format(calender.getTime());
 		} catch (ParseException e) {
-			e.printStackTrace();
+			Logger.warn("Couldn't add days", e);
 		}
 		return result;
 	}

--- a/app/transformation/GeoLookupMap.java
+++ b/app/transformation/GeoLookupMap.java
@@ -130,7 +130,7 @@ public class GeoLookupMap extends HashMap<String, String> {
 		try {
 			Thread.sleep(1000 / 6);
 		} catch (InterruptedException e) {
-			e.printStackTrace();
+			Logger.error("", e);
 		}
 	}
 

--- a/app/transformation/TripleRematch.java
+++ b/app/transformation/TripleRematch.java
@@ -13,6 +13,8 @@ import org.culturegraph.mf.framework.annotations.In;
 import org.culturegraph.mf.framework.annotations.Out;
 import org.culturegraph.mf.types.Triple;
 
+import play.Logger;
+
 /**
  * @author philipp v. böselager based on
  *         org.culturegraph.mf.stream.pipe.sort,TripleSort by markus geipel
@@ -92,7 +94,7 @@ public final class TripleRematch extends AbstractTripleRematch {
 			}
 			return;
 		} catch (IOException e) {
-			e.printStackTrace();
+			Logger.error("Problem when rematching", e);
 		}
 		return;
 	}

--- a/conf/log4j.xml
+++ b/conf/log4j.xml
@@ -3,7 +3,7 @@
 <log4j:configuration>
 	<appender name="stout" class="org.apache.log4j.ConsoleAppender">
 		<layout class="org.apache.log4j.PatternLayout">
-			<param name="ConversionPattern" value="%-5p [%t] [%c{1}] %m%n" />
+			<param name="ConversionPattern" value="%-5p [%t] [%c{10}] %m%n" />
 		</layout>
 	</appender>
 	<root>


### PR DESCRIPTION
Improve logging and recreate data

e.printStackTrace() is considered harmful.

"If you call printStackTrace() on an exception the trace is written to System.err and it's hard to route it elsewhere (or filter it). Instead of doing this you are adviced to use a logging framework."

(Source: https://stackoverflow.com/questions/10477607/avoid-printstacktrace-use-a-logger-call-instead/10477680#10477680)

Resolves #373.

- recreate data when data is not of minimum length
- make travis to use a VM with more RAM by removing "sudo: false"