### PR TITLE
Correct mapping for DBS type "UB"

### DIFF
--- a/conf/morph-enriched.xml
+++ b/conf/morph-enriched.xml
@@ -598,7 +598,7 @@
 			<entry value="http://purl.org/lobid/libtype#n36" name="Blindenbibliothek" />
 			<entry value="http://purl.org/lobid/libtype#n36" name="Patientenbibliothek" />
 			<entry value="http://purl.org/lobid/libtype#n36" name="Gefangenenbibliothek" />
-			<entry value="http://purl.org/lobid/libtype#n65" name="Universitätsbibliothek" />
+			<entry value="http://purl.org/lobid/libtype#n60" name="Universitätsbibliothek" />
 			<entry value="http://purl.org/lobid/libtype#n73" name="Fach-/Hochschulbibliothek" />
 			<entry value="http://purl.org/lobid/libtype#n81" name="Spezialbibliothek" />
 			<entry value="http://purl.org/lobid/libtype#n81" name="Musikbibliothek" />


### PR DESCRIPTION
"Universitätsbibliothek" was erroneously mapped to libtype:n65 ("Abteilungsbibliothek, Fachbereichsbibliothek, Institutsbibliothek (Universität)") while it should actualy be libtype:n60 ("Zentrale Universitätsbibliothek")