### PR TITLE
Configure new pelias instance; check geo data size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
 before_install:
   - git clone https://github.com/hbz/metafacture-core.git
   - cd metafacture-core
+  - git checkout ea0fbaf720d4277590ce5716c22155c9f675f3e5
   - mvn clean install -DskipTests=true
   - cd ..
   - wget http://downloads.typesafe.com/typesafe-activator/${ACTIVATOR_VERSION}/typesafe-activator-${ACTIVATOR_VERSION}-minimal.zip

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -17,7 +17,7 @@ index.remote=[10.1.1.106,127.0.0.1]
 
 transformation.updates.start="2013-06-01"
 transformation.updates.interval.size=50
-transformation.geo.lookup.server="http://aither.hbz-nrw.de:3100/v1/search"
+transformation.geo.lookup.server="http://gaia.hbz-nrw.de:4000/v1/search"
 transformation.geo.lookup.threshold=0.675
 transformation.sigel.repository="http://gnd-proxy.lobid.org/oai/repository"
 

--- a/cron.sh
+++ b/cron.sh
@@ -7,3 +7,11 @@ IFS=$'\n\t'
 
 curl --verbose -XPOST http://localhost:7200/organisations/transform
 curl --verbose -XPOST http://localhost:7200/organisations/index
+
+# see https://github.com/hbz/lobid-organisations/issues/419:
+totalItems=$(curl "https://lobid.org/organisations/search?q=_exists_%3AdbsID+AND+NOT+_exists_%3Aisil+AND+_exists_%3Alocation.geo"|jq .totalItems)
+if [ $totalItems -lt 4000 ]; then
+	mail -s "Missing geo data in lobid-organisations" "lobid-admin@hbz-nrw.de" -a "From: hduser@weywot1" << EOF
+See https://github.com/hbz/lobid-organisations/issues/419
+EOF
+fi


### PR DESCRIPTION
The new pelias instance is used for geo lookups.
Also, after transformations a curl is done do check if enough there is
enough geo data for the dbs IDs. If not, a mail is send.

See #419.