### PR TITLE
Revert "Proxy external links"

### DIFF
--- a/app/views/facet_map.scala.js
+++ b/app/views/facet_map.scala.js
@@ -15,7 +15,7 @@
 	}
 }
 
-var layer = L.tileLayer('https://lobid.org/osm-intl/{z}/{x}/{y}.png', {
+var layer = L.tileLayer('https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png', {
 	attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
 });
 var kassel = new L.LatLng(51.19, 9.30)

--- a/app/views/location_details.scala.js
+++ b/app/views/location_details.scala.js
@@ -47,7 +47,7 @@
 }
 
 function makeMap(i, latCoord, lonCoord, iconLabel, name, locationDetails) {
-  var layer = L.tileLayer('https://lobid.org/osm-intl/{z}/{x}/{y}.png', {
+  var layer = L.tileLayer('https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png', {
 	attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
   });
   var center = new L.LatLng(latCoord, lonCoord)


### PR DESCRIPTION
This reverts commit 2c145f09f6535fd625898553f66280e975a1f216
except the use of the image proxy and the leaflet marker.

See https://github.com/hbz/lobid/issues/421 and https://github.com/hbz/lobid-organisations/issues/430.