### PR TITLE
Update DNB OAI URL to HTTPS

### DIFF
--- a/conf/test.conf
+++ b/conf/test.conf
@@ -5,7 +5,7 @@ index.file.name=enriched-test.json
 
 transformation.updates.start="" #"2013-06-01"
 transformation.geo.lookup.server="" #"http://gaia.hbz-nrw.de:7400"
-transformation.sigel.repository="http://services.dnb.de/oai/repository" #"http://gnd-proxy.lobid.org/oai/repository"
+transformation.sigel.repository="https://services.dnb.de/oai/repository" #"http://gnd-proxy.lobid.org/oai/repository"
 
 data.input.dir = "test/transformation/input/"
 data.output.dir = "test/transformation/output/"


### PR DESCRIPTION
see https://github.com/hbz/lobid-gnd/issues/317#issuecomment-1198081452 for background

lobid-organisations also uses our DNB OAI proxy:

https://github.com/hbz/lobid-organisations/blob/26423ac148a631e691daf65201638ef794f9b4dd/conf/application.conf#L22)

So the production process should also be fixed with https://github.com/hbz/lobid-gnd/issues/317