### PR TITLE
Increasing the interval-size as workaround for #487

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -16,7 +16,8 @@ index.es.port.tcp=7310
 index.remote=[10.1.1.106,127.0.0.1]
 
 transformation.updates.start="2023-06-01"
-transformation.updates.interval.size=50
+# due to complications with the oai-pmh interval updates we increase the interval until  #487 is properly fixed.
+transformation.updates.interval.size=2000 
 transformation.geo.lookup.server="http://gaia.hbz-nrw.de:4000/v1/search"
 transformation.geo.lookup.threshold=0.675
 transformation.sigel.repository="http://gnd-proxy.lobid.org/oai/repository"


### PR DESCRIPTION
Provides a workaround for #487 but does not fix the underlying problem.
The underlying problem is that the OAI-PMH-Update process does not start the second interval since we changed the Sigel-Batch-Process.
By increasing the interval we circumvent this problem until we fix or change this problem.