### PR TITLE
Switch pelias instance from gaia to quaoar4 (#521)

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -18,7 +18,7 @@ index.remote=[10.1.1.106,127.0.0.1]
 transformation.updates.start="2024-03-01"
 # due to complications with the oai-pmh interval updates we increase the interval until  #487 is properly fixed.
 transformation.updates.interval.size=2000 
-transformation.geo.lookup.server="http://gaia.hbz-nrw.de:4000/v1/search"
+transformation.geo.lookup.server="http://quaoar4.hbz-nrw.de:4000/v1/search"
 transformation.geo.lookup.threshold=0.675
 transformation.sigel.repository="http://gnd-proxy.lobid.org/oai/repository"
 


### PR DESCRIPTION
We use a Pelias instance to do Reverse geo lookups. The old server is going to junkyard. New instance is set up.

To be merged when https://github.com/hbz/pelias-docker/pull/6 is merged.