### PR TITLE
Fix broken Java Version Upgrade #513

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,3 +43,7 @@ dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-core" % "2.6.2"
 resolvers += Resolver.mavenLocal
 
 resourceDirectory in Test := baseDirectory.value / "test" / "transformation"
+
+javacOptions ++= Seq("-source", "11", "-target", "11")
+
+import com.typesafe.sbteclipse.core.EclipsePlugin.EclipseKeys

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Mon Sep 01 16:31:39 CEST 2014
 template.uuid=5f91b045-ad7c-4a08-b31e-3f5ea4bacb81
-sbt.version=0.13.16
+sbt.version=0.13.18


### PR DESCRIPTION
`sbt run` is breaking since the Java Version upgrade https://github.com/hbz/lobid-organisations/pull/513

@dr0i we were to quick to merge this.

I had a look at @fsteeg solution for updating RPB: https://github.com/hbz/rpb/commit/0b59e22acaf0ad0c966b9420e16adeb504f8fdc7#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91 and copied the changes:

Now it runs up until it breaks like this:

```
~/git/lobid-organisations$ sbt clean run
[info] Loading project definition from /home/tobias/git/lobid-organisations/project
[info] Set current project to lobid-organisations (in build file:/home/tobias/git/lobid-organisations/)
WARNING: An illegal reflective access operation has occurred
...
...
...
(Server started, use Ctrl+D to stop and go back to the console...)

SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[info] Compiling 11 Scala sources and 15 Java sources to /home/tobias/git/lobid-organisations/target/scala-2.11/classes...
[info] /home/tobias/git/lobid-organisations/app/controllers/Reconcile.java: /home/tobias/git/lobid-organisations/app/controllers/Reconcile.java uses or overrides a deprecated API.
[info] /home/tobias/git/lobid-organisations/app/controllers/Reconcile.java: Recompile with -Xlint:deprecation for details.
[info] /home/tobias/git/lobid-organisations/app/transformation/TransformSigel.java: /home/tobias/git/lobid-organisations/app/transformation/TransformSigel.java uses unchecked or unsafe operations.
[info] /home/tobias/git/lobid-organisations/app/transformation/TransformSigel.java: Recompile with -Xlint:unchecked for details.
[error] application - 

! @8bgkbn70e - Internal server error, for (GET) [/organisations] ->

play.api.UnexpectedException: Unexpected exception[NoClassDefFoundError: java/sql/Timestamp]
        at play.core.ReloadableApplication$$anonfun$get$1$$anonfun$apply$1$$anonfun$1.apply(ApplicationProvider.scala:170) ~[play_2.11-2.3.9.jar:2.3.9]
        at play.core.ReloadableApplication$$anonfun$get$1$$anonfun$apply$1$$anonfun$1.apply(ApplicationProvider.scala:130) ~[play_2.11-2.3.9.jar:2.3.9]
        at scala.Option.map(Option.scala:146) ~[scala-library-2.11.12.jar:na]
        at play.core.ReloadableApplication$$anonfun$get$1$$anonfun$apply$1.apply(ApplicationProvider.scala:130) ~[play_2.11-2.3.9.jar:2.3.9]
        at play.core.ReloadableApplication$$anonfun$get$1$$anonfun$apply$1.apply(ApplicationProvider.scala:128) ~[play_2.11-2.3.9.jar:2.3.9]
        at scala.util.Success.flatMap(Try.scala:231) ~[scala-library-2.11.12.jar:na]
        at play.core.ReloadableApplication$$anonfun$get$1.apply(ApplicationProvider.scala:128) ~[play_2.11-2.3.9.jar:2.3.9]
        at play.core.ReloadableApplication$$anonfun$get$1.apply(ApplicationProvider.scala:120) ~[play_2.11-2.3.9.jar:2.3.9]
        at scala.concurrent.impl.Future$PromiseCompletingRunnable.liftedTree1$1(Future.scala:24) ~[scala-library-2.11.12.jar:na]
        at scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:24) ~[scala-library-2.11.12.jar:na]
Caused by: java.lang.NoClassDefFoundError: java/sql/Timestamp
        at com.fasterxml.jackson.databind.ser.BasicSerializerFactory.<clinit>(BasicSerializerFactory.java:89) ~[jackson-databind-2.6.2.jar:2.6.2]
        at com.fasterxml.jackson.databind.ObjectMapper.<init>(ObjectMapper.java:548) ~[jackson-databind-2.6.2.jar:2.6.2]
        at com.fasterxml.jackson.databind.ObjectMapper.<init>(ObjectMapper.java:449) ~[jackson-databind-2.6.2.jar:2.6.2]
        at play.core.ObjectMapperPlugin.onStart(ObjectMapperPlugin.scala:20) ~[play-java_2.11-2.3.9.jar:2.3.9]
        at play.api.Play$$anonfun$start$1$$anonfun$apply$mcV$sp$1.apply(Play.scala:91) ~[play_2.11-2.3.9.jar:2.3.9]
        at play.api.Play$$anonfun$start$1$$anonfun$apply$mcV$sp$1.apply(Play.scala:91) ~[play_2.11-2.3.9.jar:2.3.9]
        at scala.collection.immutable.List.foreach(List.scala:392) ~[scala-library-2.11.12.jar:na]
        at play.api.Play$$anonfun$start$1.apply$mcV$sp(Play.scala:91) ~[play_2.11-2.3.9.jar:2.3.9]
        at play.api.Play$$anonfun$start$1.apply(Play.scala:91) ~[play_2.11-2.3.9.jar:2.3.9]
        at play.api.Play$$anonfun$start$1.apply(Play.scala:91) ~[play_2.11-2.3.9.jar:2.3.9]
Caused by: java.lang.ClassNotFoundException: java.sql.Timestamp
        at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476) ~[na:na]
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:594) ~[na:na]
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527) ~[na:na]
        at com.fasterxml.jackson.databind.ser.BasicSerializerFactory.<clinit>(BasicSerializerFactory.java:89) ~[jackson-databind-2.6.2.jar:2.6.2]
        at com.fasterxml.jackson.databind.ObjectMapper.<init>(ObjectMapper.java:548) ~[jackson-databind-2.6.2.jar:2.6.2]
        at com.fasterxml.jackson.databind.ObjectMapper.<init>(ObjectMapper.java:449) ~[jackson-databind-2.6.2.jar:2.6.2]
        at play.core.ObjectMapperPlugin.onStart(ObjectMapperPlugin.scala:20) ~[play-java_2.11-2.3.9.jar:2.3.9]
        at play.api.Play$$anonfun$start$1$$anonfun$apply$mcV$sp$1.apply(Play.scala:91) ~[play_2.11-2.3.9.jar:2.3.9]
        at play.api.Play$$anonfun$start$1$$anonfun$apply$mcV$sp$1.apply(Play.scala:91) ~[play_2.11-2.3.9.jar:2.3.9]
        at scala.collection.immutable.List.foreach(List.scala:392) ~[scala-library-2.11.12.jar:na]
```